### PR TITLE
Remove compiler flag overrides

### DIFF
--- a/docker/scripts/build_larcontent.sh
+++ b/docker/scripts/build_larcontent.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e # script must exit if an error occurs
 
-source /pandora/set_compiler_flags.sh
-
 # Build project
 mkdir build
 cd build


### PR DESCRIPTION
The latest .travis.yml file for LArContent sets the compiler. Specific compiler versions are set, so avoid overriding those settings here.